### PR TITLE
Environment set/use WASPTLS

### DIFF
--- a/wasp.c
+++ b/wasp.c
@@ -59,6 +59,11 @@ main (int argc, const char *argv[])
             waspport = p + 1;
          port = waspport;
       }
+      char *wasptls = getenv ("WASPTLS");
+      if (wasptls)
+      {
+         tls = 1;
+      }
    }
    poptContext optCon;          // context for parsing command-line options
    {                            // POPT

--- a/waspserver.c
+++ b/waspserver.c
@@ -314,6 +314,10 @@ wasp_script (wasp_session_t * s, const char *script, xml_t head, size_t len, con
       errx (1, "malloc");
    if (s->id && asprintf (env (), "WASPID=%s", s->id) < 0)
       errx (1, "malloc");
+   if (keyfile && certfile) {
+      if (s->id && asprintf (env (), "WASPTLS=1") < 0)
+         errx(1, "malloc");
+   }
    if (s->ws)
    {
       unsigned long ping = websocket_ping (s->ws);


### PR DESCRIPTION
Wasp.c now uses WASPTLS from the environment to set tls
Waspserver.c now sets WASPTLS if using key and cert when starting a shell
